### PR TITLE
Run CI on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - master
     tags: '*'
+defaults:
+  run:
+    shell: bash
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -20,6 +23,7 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
+          - windows-latest
         arch:
           - x64
           - x86


### PR DESCRIPTION
This PR runs CI on three operating systems:
1. Linux (Ubuntu)
2. macOS
3. Windows