### PR TITLE
lock keyword: let arg_{read,write} caller determine locking

### DIFF
--- a/src/ArgTools.jl
+++ b/src/ArgTools.jl
@@ -74,14 +74,13 @@ arg_read(f::Function, arg::IO; lock::Bool=true) = f(arg)
 
 VERSION ≥ v"1.5" &&
 function arg_read(f::Function, arg::IOStream; lock::Bool=true)
-    arg_dolock = arg._dolock
-    arg._dolock = lock
-    try # take outer lock if !lock
-        lock || Base.lock(arg)
+    # confusing, lock=true means `f` is potentially multi-threaded (therefore locking here is bad, and will also disable finalizers)
+    # while lock=false means it is single-threaded (so locking here is good hygiene, though it may disable finalizers)
+    lock || Base.lock(arg)
+    try
         f(arg)
     finally
         lock || unlock(arg)
-        arg._dolock = arg_dolock
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,6 +67,38 @@ end
     rm(src_file)
 end
 
+@testset "lock keyword" begin
+    @testset "arg_read" begin
+        path = tempname()
+        touch(path)
+        arg_readers(path) do arg
+            for lock in false:true
+                @arg_test arg begin
+                    arg_read(arg, lock=lock) do io
+                        if arg isa IOStream
+                            @test io._dolock == lock
+                        end
+                    end
+                end
+            end
+        end
+        rm(path)
+    end
+    @testset "arg_write" begin
+        arg_writers() do path, arg
+            for lock in false:true
+                @arg_test arg begin
+                    arg_write(arg, lock=lock) do io
+                        if arg isa IOStream
+                            @test io._dolock == lock
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
 ## for testing error handling ##
 
 struct ErrIO <: IO end


### PR DESCRIPTION
Instead of unconditionally opening files with `lock=false`, this allows the caller of `arg_read` or `arg_write` to pass a boolean `lock` keyword argument to determine whether `IOStream` objects should do per-operation locking or not. For `IOStream` objects created by opening a file, this calls `open` with the `lock` keyword. For `IOStream` objects passed into the `arg_read` or `arg_write` call, if `lock=false` the `IOStream` is locked once for the whole operation and then the `_dolock` field is set to `false` and restored upon termination of the block.