### PR TITLE
[doc] add index file

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,7 @@
 # ArgTools
 
+## Argument Handling
+
 ```@docs
 ArgTools.ArgRead
 ArgTools.ArgWrite
@@ -7,6 +9,12 @@ ArgTools.arg_read
 ArgTools.arg_write
 ArgTools.arg_isdir
 ArgTools.arg_mkdir
+```
+
+
+## Function Testing
+
+```@docs
 ArgTools.arg_readers
 ArgTools.arg_writers
 ArgTools.@arg_test

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,10 @@
+# ArgTools
+
+```@docs
+ArgTools.ArgRead
+ArgTools.ArgWrite
+ArgTools.arg_read
+ArgTools.arg_write
+ArgTools.arg_isdir
+ArgTools.arg_mkdir
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,4 +7,7 @@ ArgTools.arg_read
 ArgTools.arg_write
 ArgTools.arg_isdir
 ArgTools.arg_mkdir
+ArgTools.arg_readers
+ArgTools.arg_writers
+ArgTools.@arg_test
 ```


### PR DESCRIPTION
fix #18

Should we move the ["Examples" section](https://github.com/JuliaIO/ArgTools.jl#examples) to the docs?

