### PR TITLE
fix tests for Lockable PR

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArgTools"
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 authors = ["Stefan Karpinski <stefan@karpinski.org> and contributors"]
-version = "1.1.1"
+version = "1.1.2"
 
 [compat]
 julia = "1.3"


### PR DESCRIPTION
Tests are failing on https://github.com/JuliaLang/julia/pull/52898 because the tests here rely on implementation details of `TEMP_CLEANUP`. If we want to go with that PR, we should first merge this and update the stdlib used on master so tests stop failing on https://github.com/JuliaLang/julia/pull/52898.