### PR TITLE
ArgTools: Add FileSpec writer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArgTools"
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 authors = ["Stefan Karpinski <stefan@karpinski.org> and contributors"]
-version = "1.1.2"
+version = "1.2.0"
 
 [compat]
 julia = "1.3"

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ sure everything is working as intended.
 
 ### Argument Handling
 
-The API for helping defining flexible function signatures consists of two types
-and four helper functions: `ArgRead` and `ArgWrite`; `arg_read`, `arg_write`,
-`arg_isdir` and `arg_mkdir`.
+The API for helping defining flexible function signatures consists of three
+types and four helper functions: `ArgRead`, `ArgWrite` and `FileSpec`;
+`arg_read`, `arg_write`, `arg_isdir` and `arg_mkdir`.
 
 <!-- BEGIN: copied from inline doc strings -->
 
@@ -42,11 +42,22 @@ how to convert into readable IO handles. See [`arg_read`](@ref) for details.
 #### ArgWrite
 
 ```jl
-ArgWrite = Union{AbstractString, AbstractCmd, IO}
+ArgWrite = Union{AbstractString, AbstractCmd, IO, FileSpec}
 ```
 The `ArgWrite` types is a union of the types that the `arg_write` function knows
 how to convert into writeable IO handles, except for `Nothing` which `arg_write`
 handles by generating a temporary file. See [`arg_write`](@ref) for details.
+
+#### FileSpec
+
+```jl
+FileSpec(path::AbstractString, [ mode::Integer = 0o666 ])
+FileSpec(path::AbstractString; [ mode::Integer = 0o666 ])
+```
+
+A `FileSpec` represents a file path and additional options used by
+`arg_write`. The file will be opened for writing with the specified access
+`mode`, modified by the process umask.
 
 #### arg_read
 
@@ -67,11 +78,13 @@ flushed but not closed before returning from `arg_read`.
 
 ```jl
 arg_write(f::Function, arg::ArgWrite) -> arg
+arg_write(f::Function, arg::FileSpec) -> arg.path
 arg_write(f::Function, arg::Nothing) -> tempname()
 ```
 The `arg_write` function accepts an argument `arg` that can be any of these:
 
 - `AbstractString`: a file path to be opened for writing
+- `FileSpec`: a file path and options to be used when opening for writing
 - `AbstractCmd`: a command to be run, writing to its standard input
 - `IO`: an open IO handle to be written to
 - `Nothing`: a temporary path should be written to
@@ -79,9 +92,10 @@ The `arg_write` function accepts an argument `arg` that can be any of these:
 If the body returns normally, a path that is opened will be closed upon
 completion; an IO handle argument is left open but flushed before return. If the
 argument is `nothing` then a temporary path is opened for writing and closed
-open completion and the path is returned from `arg_write`. In all other cases,
-`arg` itself is returned. This is a useful pattern since you can consistently
-return whatever was written, whether an argument was passed or not.
+open completion and the path is returned from `arg_write`. If the argument is a
+`FileSpec`, then its path is returned. In all other cases, `arg` itself is
+returned. This is a useful pattern since you can consistently return whatever
+was written, whether an argument was passed or not.
 
 If there is an error during the evaluation of the body, a path that is opened by
 `arg_write` for writing will be deleted, whether it's passed in as a string or a

--- a/src/ArgTools.jl
+++ b/src/ArgTools.jl
@@ -3,7 +3,7 @@ module ArgTools
 export
     arg_read,  ArgRead,  arg_readers,
     arg_write, ArgWrite, arg_writers,
-    arg_isdir, arg_mkdir, @arg_test
+    arg_isdir, arg_mkdir, FileSpec, @arg_test
 
 import Base: AbstractCmd, CmdRedirect, Process
 
@@ -48,13 +48,31 @@ how to convert into readable IO handles. See [`arg_read`](@ref) for details.
 const ArgRead = Union{AbstractString, AbstractCmd, IO}
 
 """
-    ArgWrite = Union{AbstractString, AbstractCmd, IO}
+    FileSpec(path::AbstractString, [ mode::Integer = 0o666 ])
+    FileSpec(path::AbstractString; [ mode::Integer = 0o666 ])
+
+A `FileSpec` represents a file path and additional options used by
+[`arg_write`](@ref). The file will be opened for writing with the specified
+access `mode`, modified by the process umask.
+"""
+struct FileSpec
+    path::String
+    mode::UInt16
+
+    FileSpec(path::AbstractString, mode::Integer) =
+        new(String(path), UInt16(Base.Filesystem.checkmode(mode)))
+end
+
+FileSpec(path::AbstractString; mode::Integer = 0o666) = FileSpec(path, mode)
+
+"""
+    ArgWrite = Union{AbstractString, AbstractCmd, IO, FileSpec}
 
 The `ArgWrite` types is a union of the types that the `arg_write` function knows
 how to convert into writeable IO handles, except for `Nothing` which `arg_write`
 handles by generating a temporary file. See [`arg_write`](@ref) for details.
 """
-const ArgWrite = Union{AbstractString, AbstractCmd, IO}
+const ArgWrite = Union{AbstractString, AbstractCmd, IO, FileSpec}
 
 """
     arg_read(f::Function, arg::ArgRead) -> f(arg_io)
@@ -77,11 +95,13 @@ arg_read(f::Function, arg::IO) = f(arg)
 
 """
     arg_write(f::Function, arg::ArgWrite) -> arg
+    arg_write(f::Function, arg::FileSpec) -> arg.path
     arg_write(f::Function, arg::Nothing) -> tempname()
 
 The `arg_write` function accepts an argument `arg` that can be any of these:
 
 - `AbstractString`: a file path to be opened for writing
+- `FileSpec`: a file path and options to be used when opening for writing
 - `AbstractCmd`: a command to be run, writing to its standard input
 - `IO`: an open IO handle to be written to
 - `Nothing`: a temporary path should be written to
@@ -89,9 +109,10 @@ The `arg_write` function accepts an argument `arg` that can be any of these:
 If the body returns normally, a path that is opened will be closed upon
 completion; an IO handle argument is left open but flushed before return. If the
 argument is `nothing` then a temporary path is opened for writing and closed
-open completion and the path is returned from `arg_write`. In all other cases,
-`arg` itself is returned. This is a useful pattern since you can consistently
-return whatever was written, whether an argument was passed or not.
+open completion and the path is returned from `arg_write`. If the argument is a
+`FileSpec`, then its path is returned. In all other cases, `arg` itself is
+returned. This is a useful pattern since you can consistently return whatever
+was written, whether an argument was passed or not.
 
 If there is an error during the evaluation of the body, a path that is opened by
 `arg_write` for writing will be deleted, whether it's passed in as a string or a
@@ -106,6 +127,27 @@ function arg_write(f::Function, arg::AbstractString)
         rethrow()
     end
     return arg
+end
+
+function arg_write(f::Function, arg::FileSpec)
+    try
+        io = Base.Filesystem.open(
+            arg.path,
+            Base.Filesystem.JL_O_WRONLY |
+            Base.Filesystem.JL_O_CREAT |
+            Base.Filesystem.JL_O_TRUNC,
+            arg.mode,
+        )
+        try
+            f(io)
+        finally
+            close(io)
+        end
+    catch
+        rm(arg.path, force=true)
+        rethrow()
+    end
+    return arg.path
 end
 
 function arg_write(f::Function, arg::AbstractCmd)
@@ -211,6 +253,7 @@ const ARG_READERS = [
 
 const ARG_WRITERS = [
     String      => path -> f -> f(path)
+    FileSpec    => path -> f -> f(FileSpec(path))
     Cmd         => path -> f -> f(`tee $path`)
     CmdRedirect => path -> f -> f(pipeline(`cat`, path))
     IOStream    => path -> f -> open(f, path, write=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,8 @@ function send_data(src::ArgRead, dst::Union{ArgWrite, Nothing} = nothing)
     end
 end
 
+expected_arg(arg) = arg isa FileSpec ? arg.path : arg
+
 @testset "arg_{read,write}" begin
     # create a source file
     src_file = tempname()
@@ -23,10 +25,11 @@ end
 
     # record what we want to test
     signatures = Set()
-    types = [String, Cmd, Base.CmdRedirect, IOStream, Base.Process]
-    for S in types
+    read_types = [String, Cmd, Base.CmdRedirect, IOStream, Base.Process]
+    write_types = [read_types..., FileSpec]
+    for S in read_types
         push!(signatures, Tuple{S})
-        for D in types
+        for D in write_types
             push!(signatures, Tuple{S,D})
         end
     end
@@ -43,7 +46,7 @@ end
             @test !ispath(dst_file)
             @arg_test src dst begin
                 pop!(signatures, Tuple{typeof(src), typeof(dst)})
-                @test dst == send_data(src, dst)
+                @test expected_arg(dst) == send_data(src, dst)
             end
             @test data == read(dst_file)
         end
@@ -53,11 +56,36 @@ end
         arg_writers(dst_file) do dst
             @test !ispath(dst_file)
             @arg_test src dst begin
-                @test dst == send_data(src, dst)
+                @test expected_arg(dst) == send_data(src, dst)
             end
             @test data == read(dst_file)
             rm(dst_file)
         end
+    end
+
+    @testset "arg_write(FileSpec)" begin
+        dst_file = tempname()
+        mode = 0o600
+        expected = Sys.iswindows() ? 0o666 : mode
+        @test FileSpec(dst_file; mode).mode === UInt16(mode)
+        @test dst_file == arg_write(FileSpec(dst_file; mode)) do dst_io
+            write(dst_io, data)
+        end
+        @test data == read(dst_file)
+        @test filemode(dst_file) & 0o777 == expected
+        rm(dst_file)
+
+        dst_file = tempname()
+        write(dst_file, "old")
+        old_mode = filemode(dst_file) & 0o777
+        @test dst_file == arg_write(FileSpec(dst_file; mode)) do dst_io
+            write(dst_io, data)
+        end
+        @test data == read(dst_file)
+        @test filemode(dst_file) & 0o777 == old_mode
+        rm(dst_file)
+
+        @test_throws ArgumentError FileSpec(tempname(); mode=0o1000)
     end
 
     # test that we tested all signatures
@@ -81,6 +109,11 @@ import Base.Filesystem: TEMP_CLEANUP
     @testset "arg_write(path)" begin
         dst = tempname()
         @test_throws ErrorException send_data(ErrIO(), dst)
+        @test !isfile(dst)
+    end
+    @testset "arg_write(FileSpec)" begin
+        dst = tempname()
+        @test_throws ErrorException send_data(ErrIO(), FileSpec(dst))
         @test !isfile(dst)
     end
     # post-https://github.com/JuliaLang/julia/pull/52898 we need to acquire


### PR DESCRIPTION
Add FileSpec as an ArgWrite target that carries a path and file creation mode. A particular motivation is specifying a file mode for the result of `download`.